### PR TITLE
Add feature for full season statcast batter data

### DIFF
--- a/pybaseball/statcast_batter.py
+++ b/pybaseball/statcast_batter.py
@@ -1,5 +1,5 @@
 from pybaseball.utils import sanitize_input, split_request
-
+import pandas as pd
 
 def statcast_batter(start_dt=None, end_dt=None, player_id=None):
     """
@@ -16,3 +16,9 @@ def statcast_batter(start_dt=None, end_dt=None, player_id=None):
         url = 'https://baseballsavant.mlb.com/statcast_search/csv?all=true&hfPT=&hfAB=&hfBBT=&hfPR=&hfZ=&stadium=&hfBBL=&hfNewZones=&hfGT=R%7CPO%7CS%7C=&hfSea=&hfSit=&player_type=batter&hfOuts=&opponent=&pitcher_throws=&batter_stands=&hfSA=&game_date_gt={}&game_date_lt={}&batters_lookup%5B%5D={}&team=&position=&hfRO=&home_road=&hfFlag=&metric_1=&hfInn=&min_pitches=0&min_results=0&group_by=name&sort_col=pitches&player_event_sort=h_launch_speed&sort_order=desc&min_abs=0&type=details&'
         df = split_request(start_dt, end_dt, player_id, url)
         return df
+    
+def statcast_batter_exitVeloBarrels(year, minBBE="q"):
+    url = f"https://baseballsavant.mlb.com/leaderboard/statcast?type=batter&year={year}&position=&team=&min={minBBE}&csv=true"
+    res = requests.get(url, timeout=None).content
+    data = pd.read_csv(io.StringIO(res.decode('utf-8')))
+    return data


### PR DESCRIPTION
Currently, statcast batter data can only be queried for individual players by playerID. This change extends the functionality to allow querying full season data related to exit velocity and other launch data across all batters.